### PR TITLE
Organize into databases

### DIFF
--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -463,9 +463,11 @@ def pairs(data, fieldname=None):
     Usage: out_array = pairs(data, fieldname)
     Works with Lists or tuples as data input only.
     Fieldname not included yet. 
+    Notes::
     Uses list comprehension in tuple creation. Maybe use numba jit or numpy.ndarray.view() ?
+    Records are probably a invalid field in this case, as a unique (key, value) pair can't be maintained.  
     '''
-    from oamap.schema import *
+    from oamap.schema import List, Tuple
     if isinstance(data, oamap.proxy.ListProxy) or isinstance(data, oamap.proxy.TupleProxy) or isinstance(data, list) or isinstance(data, tuple) or isinstance(data, numpy.ndarray):
         if fieldname is None:
             # No fieldname given, We are free to choose out own. Let's return a nested List

--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -253,6 +253,7 @@ def pairs(data, fieldname=None):
             # For returning tuples, uncomment. List comprehension is unfortunately required, maybe I am missing soemthing?
             #schema = List(Tuple(['float','float']))
             #arr2 = [tuple(l) for l in arr1]
+            #obj = schema.fromdata(arr2)
             obj = schema.fromdata(arr1)
             return obj
         else:

--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -234,6 +234,31 @@ def flatten(data):
     else:
         raise TypeError("flatten can only be applied to List(List(...))")
 
+
+def pairs(data, fieldname=None):
+    '''
+    data = 1D numpy array, list , tuple, or a List() or Tuple(). 
+    fieldname = output numpy array. Will be returned from the function.
+    Usage: out_array = pairs(data, fieldname)
+    Works with Lists or tuples as data input only.
+    Fieldname not included yet. 
+    '''
+    from oamap.schema import *
+    if isinstance(data, oamap.proxy.ListProxy) or isinstance(data, oamap.proxy.TupleProxy) or isinstance(data, list) or isinstance(data, tuple) or isinstance(data, numpy.ndarray):
+        if fieldname is None:
+            # No fieldname given, We are free to choose out own. Let's return a nested List
+            arr = numpy.array(data)
+            arr1 = numpy.ndarray.tolist(arr[numpy.transpose(numpy.triu_indices(len(arr), 1))])
+            schema = List(List('float'))
+            # For returning tuples, uncomment. List comprehension is unfortunately required, maybe I am missing soemthing?
+            #schema = List(Tuple(['float','float']))
+            #arr2 = [tuple(l) for l in arr1]
+            obj = schema.fromdata(arr1)
+            return obj
+        else:
+            raise NotImplementedError("Will be available when records are available")
+    else:
+        raise NotImplementedError("Works with Lists or Tuple data only")
 ################################################################ filter
 
 def filter(data, fcn, args=(), numba=True, fieldname=None):

--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -472,7 +472,7 @@ def pairs(data, fieldname=None):
         if fieldname is None:
             # No fieldname given, We are free to choose out own. Let's return a nested List
             arr = numpy.array(data)
-            arr1 = numpy.ndarray.tolist(arr[numpy.transpose(numpy.triu_indices(len(arr), 1))])
+            arr1 = arr[numpy.transpose(numpy.triu_indices(len(arr), 1))]
             schema = List(List('float'))
             # For returning tuples, uncomment. List comprehension is unfortunately required, maybe I am missing soemthing?
             #schema = List(Tuple(['float','float']))

--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -456,32 +456,33 @@ def flatten(data, at=""):
 ################################################################ pairs
 >>>>>>> 9729f418ae4771723f29f8f7b7a9859d28957ab6
 
-def pairs(data, fieldname=None):
+def pairs(data, otype="LL"):
     '''
     data = 1D numpy array, list , tuple, or a List() or Tuple(). 
-    fieldname = output numpy array. Will be returned from the function.
-    Usage: out_array = pairs(data, fieldname)
+    otype = output schema type. Possible values are LL (List of Lists), or LT (List of Tuples).
+    returns a double precision List of Lists or List of Tuples. 
+    Usage: out_array = pairs(data, otype)
     Works with Lists or tuples as data input only.
     Fieldname not included yet. 
-    Notes::
-    Uses list comprehension in tuple creation. Maybe use numba jit or numpy.ndarray.view() ?
-    Records are probably a invalid field in this case, as a unique (key, value) pair can't be maintained.  
+    Uses list comprehension in tuple creation. 
     '''
     from oamap.schema import List, Tuple
     if isinstance(data, oamap.proxy.ListProxy) or isinstance(data, oamap.proxy.TupleProxy) or isinstance(data, list) or isinstance(data, tuple) or isinstance(data, numpy.ndarray):
-        if fieldname is None:
-            # No fieldname given, We are free to choose out own. Let's return a nested List
+        if otype is "LL":
             arr = numpy.array(data)
             arr1 = arr[numpy.transpose(numpy.triu_indices(len(arr), 1))]
-            schema = List(List('float'))
-            # For returning tuples, uncomment. List comprehension is unfortunately required, maybe I am missing soemthing?
-            #schema = List(Tuple(['float','float']))
-            #arr2 = [tuple(l) for l in arr1]
-            #obj = schema.fromdata(arr2)
+            schema = List(List('double'))
             obj = schema.fromdata(arr1)
+            return obj
+        elif otype is "LT":
+            arr = numpy.array(data)
+            arr1 = arr[numpy.transpose(numpy.triu_indices(len(arr), 1))]
+            schema = List(Tuple(['double','double']))
+            obj = schema.fromdata([tuple(l) for l in arr1])
             return obj
         else:
             raise NotImplementedError("Will be available when records are available")
+            
     else:
         raise NotImplementedError("Works with Lists or Tuple data only")
 ################################################################ filter

--- a/oamap/operations.py
+++ b/oamap/operations.py
@@ -344,9 +344,9 @@ def {fill}({data}, {innerstarts}, {stops}, {pointers}{params}):
 
 ################################################################ quick test
 
-from oamap.schema import *
+# from oamap.schema import *
 
-dataset = List(Record(dict(x=List("int"), y=List("double")))).fromdata([{"x": [1, 2, 3], "y": [1.1, 2.2]}, {"x": [], "y": []}, {"x": [4, 5], "y": [3.3]}])
+# dataset = List(Record(dict(x=List("int"), y=List("double")))).fromdata([{"x": [1, 2, 3], "y": [1.1, 2.2]}, {"x": [], "y": []}, {"x": [4, 5], "y": [3.3]}])
 
 # dataset = List(List("int")).fromdata([[1, 2, 3], [], [4, 5]])
 


### PR DESCRIPTION
## Implementation of pairs function in numpy with triu_indices. 
Returns a List by default. Can be changed to return a List of Tuples though through switch?

#### Caveats

- Tuple creation will unfortunately, require list comprehension. Possible numpy alternative is numba or numpy.ndarray.view. But it will require assumptions about dtype, while being potentially slower. Considering for future work.
- Currently returns double precision List or Tuple.  Maybe have a way of inferring dtype from input List, and return same output dtype. 
- Another possible speedup can be achieved, if numpy arrays are fed into the function. The current implementation requires converting the List or Tuple data to numpy array for processing, which is slow.

#### Notes

- Records may not be possible to add, as they will require unique (key, value) pairs, which is not feasible in this case. But of course, feel free to suggest a way to do it.